### PR TITLE
docs(fix): code example can not compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 import * as ColorMath from "color-math"
 
 // will return color which is result of mixing red and green colors
-const result = ColorMath.evaluate("red | green")
+let result = ColorMath.evaluate("red | green")
 // prints "#804000" ('result.result' is a chroma.js instance; see link below)
 console.log(result.result.hex())
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -293,9 +293,11 @@ export declare namespace Evaluators {
   }
 
   export class CoreEvaluator extends EvaluatorBase {
+     constructor()
   }
 
   export class LessEvaluator extends EvaluatorBase {
+     constructor()
   }
 }
 


### PR DESCRIPTION
Cannot [re]assign to 'result' because it is a constant.
closes #4 (Can not use code example as is)